### PR TITLE
Replaced `apiKey` parameter with `clientId`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The plugin is based on [Android/IOS SDK](https://yandex.ru/support2/varioqub-app
 
 All functionality is described in example
 ### Initialization
-```await Varioqub.init(apiKey:'appmetrica.XXXXXXX');``` - used to initialize Varioqub, where XXXXXXX is the numeric id of the AppMetrica project
+```await Varioqub.init(clientId:'appmetrica.XXXXXXX');``` - used to initialize Varioqub, where XXXXXXX is the numeric id of the AppMetrica project
 
 ### Default values
 ```await Varioqub.setDefault(

--- a/README.ru.md
+++ b/README.ru.md
@@ -13,7 +13,7 @@ Flutter плагин для сервиса A/B тестирования от Yan
 
 Весь функционал описан в example
 ### Инициализация
-```await Varioqub.init(apiKey:'appmetrica.XXXXXXX');``` - используется для инициализации Varioqub, где XXXXXXX - числовой id AppMetrica проекта
+```await Varioqub.init(clientId:'appmetrica.XXXXXXX');``` - используется для инициализации Varioqub, где XXXXXXX - числовой id AppMetrica проекта
 
 ### Default значения
 ```await Varioqub.setDefault(

--- a/android/src/main/kotlin/com/smena/flutter_varioqub/FlutterVarioqubPlugin.kt
+++ b/android/src/main/kotlin/com/smena/flutter_varioqub/FlutterVarioqubPlugin.kt
@@ -3,8 +3,6 @@ package com.smena.flutter_varioqub
 import android.app.Application
 import android.content.Context
 import androidx.annotation.NonNull
-import com.yandex.metrica.YandexMetrica
-import com.yandex.metrica.YandexMetricaConfig
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -32,11 +30,11 @@ class FlutterVarioqubPlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
         when (call.method) {
             "init" -> {
-                val apiKey = call.argument<String?>("api_key")
-                if (apiKey == null) {
-                    result.error("API key = null", null, null)
+                val clientId = call.argument<String?>("client_id")
+                if (clientId == null) {
+                    result.error("Client id (appmetrica.XXXXXXX) = null", null, null)
                 }
-                val settings = VarioqubSettings.Builder(apiKey!!).withThrottleInterval(100)
+                val settings = VarioqubSettings.Builder(clientId!!).withThrottleInterval(100)
                     .build()
 
                 Varioqub.init(settings, AppmetricaAdapter(context!!), context!!)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> init() async {
-    await Varioqub.init(apiKey: 'appmetrica.XXXXXXX'); // XXXXXXX - App ID Yandex Metrica
+    await Varioqub.init(clientId: 'appmetrica.XXXXXXX'); // XXXXXXX - App ID Yandex Metrica
     await Varioqub.setDefault(
       defaultMap: {
         'test_string': 'default_string',

--- a/ios/Classes/FlutterVarioqubPlugin.swift
+++ b/ios/Classes/FlutterVarioqubPlugin.swift
@@ -16,9 +16,9 @@ public class FlutterVarioqubPlugin: NSObject, FlutterPlugin {
     let arguments = call.arguments as? NSDictionary
     switch call.method {
     case "init":
-        guard let apiKey = arguments?["api_key"] as? String else {
+        guard let clientId = arguments?["client_id"] as? String else {
                         result(
-                            FlutterError(code: "API key = null",
+                            FlutterError(code: "Client id (appmetrica.XXXXXXX) = null",
                                 message: nil,
                                 details: nil))
                         return
@@ -26,7 +26,7 @@ public class FlutterVarioqubPlugin: NSObject, FlutterPlugin {
         var vqCfg = VarioqubConfig.default
 
 
-        VarioqubFacade.shared.initialize(apiKey: apiKey, config: vqCfg, idProvider: nil, reporter: nil)
+        VarioqubFacade.shared.initialize(clientId: clientId, config: vqCfg, idProvider: nil, reporter: nil)
         
         result(nil)
     case "set_default":

--- a/lib/flutter_varioqub.dart
+++ b/lib/flutter_varioqub.dart
@@ -3,8 +3,8 @@ import 'package:flutter/services.dart';
 class Varioqub {
   static const MethodChannel _channel = MethodChannel('flutter_varioqub');
 
-  static Future<void> init({required String apiKey}) async {
-    return await _channel.invokeMethod<void>('init', {'api_key': apiKey});
+  static Future<void> init({required String clientId}) async {
+    return await _channel.invokeMethod<void>('init', {'client_id': clientId});
   }
 
   static Future<void> setDefault(


### PR DESCRIPTION
## Description of Changes

This pull request introduces the following changes to the project:

* Fixed a compilation error in iOS related to incorrect argument label in the VarioqubFacade.shared.initialize call.
* Replaced the apiKey parameter with clientId as per the expected method interface.
* Updates documentation.

## Why These Changes Matter

The compilation error was occurring due to a mismatch in the argument label, preventing successful compilation of the iOS application using the flutter_varioqub package. This fix allows the application to compile successfully and operate with the flutter_varioqub package on iOS.

## Testing of Changes

Tested on iOS Simulator 17.4 and Google Pixel 6.

## Related Issues

This pull request resolves issue #1.

## Expected Impact

Upon merging this pull request into the main project branch, we expect the compilation error on iOS to be resolved, enabling seamless development using the flutter_varioqub package.